### PR TITLE
Increase readability and simplify the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ Requirements
  * [Bash](https://www.gnu.org/software/bash/)
  * [mawk](http://invisible-island.net/mawk/mawk.html) or [GNU AWK](https://www.gnu.org/software/gawk/)
  * [jq](https://github.com/stedolan/jq)
- * [publicsuffix](https://packages.debian.org/stable/publicsuffix)
 
 All the packages are available on the latest [Debian](https://debian.org) stable (jessie, at the time of writing), and may be installed using:
 ```bash
-sudo apt-get install bash awk jq publicsuffix
+sudo apt-get install -y bash awk jq
+```
+For RedHat based systems (CentOS, Fedora, AlmaLinux, RockyLinux etc.):
+```bash
+sudo dnf install -y bash gawk jq
 ```
 
 Configuration
@@ -33,3 +36,7 @@ For this method, you'd need to `export` the `CF_TOKEN` variable, with a suitable
 This method is less secure, as if someone were capable of reading these keys they'd have full access to your account.
 
 For this method, you'd need to `export` the `CF_EMAIL` and `CF_KEY` variables with your CloudFlare email and API key respectively.
+
+### cftoken file
+
+Alternatively the variables `CF_EMAIL`, `CF_KEY` or `CF_TOKEN` can be added to the cftoken file. They will be read in at execution of the hook. The cftoken file needs to be in the same directory as the hook.sh for it to be read in.

--- a/cf-hook.sh
+++ b/cf-hook.sh
@@ -1,203 +1,208 @@
 #!/bin/bash
+# shellcheck disable=SC2155
+# shellcheck disable=SC2162
+# shellcheck disable=SC2181
+# shellcheck disable=SC2173
 
-log() {
-	echo "   $*" 1>&2
+
+log () {
+	printf "   %s\n" "${*}" 1>&2
 }
 
-success() {
-	echo " + $*" 1>&2
+success () {
+	printf " + %s\n" "${*}" 1>&2
 }
 
-error() {
-	echo "ERROR: $*" 1>&2
+error () {
+	printf "ERROR: %s\n" "${*}" 1>&2
 }
 
 # exit inside a $() does not work, so we will roll out our own
 scriptexitval=1
 trap "exit \$scriptexitval" SIGKILL
-abort() {
+abort () {
 	scriptexitval=$1
 	kill 0
 }
 
-cf_req() {
+cf_req () {
 	local response
-	if [ ! -z "${CF_TOKEN}" ]; then
-		response=$(curl -s -H "Authorization: Bearer ${CF_TOKEN}" -H "Content-Type: application/json" $*)
-	elif [ ! -z "${CF_EMAIL}" ] && [ ! -z "${CF_KEY}" ]; then
-		response=$(curl -s -H "X-Auth-Email: ${CF_EMAIL}" -H "X-Auth-Key: ${CF_KEY}" -H "Content-Type: application/json" $*)
-	else
-		error "Missing CF keys"
-		abort 1
+	
+	localdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
+	if [[ -f "${localdir}/cftoken" ]]
+    then
+      source "${localdir}/cftoken"
+  fi
+
+	if [[ -n "${CF_TOKEN}" ]]
+    then
+      response=$( curl -s \
+                  -H "Authorization: Bearer ${CF_TOKEN}" \
+                  -H "Content-Type: application/json" \
+                      "${@}"
+                )     
+	elif [[ -n "${CF_EMAIL}" ]] && [[ -n "${CF_KEY}" ]]
+    then
+      response=$( curl -s \
+                  -H "X-Auth-Email: ${CF_EMAIL}" \
+                  -H "X-Auth-Key: ${CF_KEY}" \
+                  -H "Content-Type: application/json" \
+                      "${@}"
+                )        
+	  else
+      error "Missing CF keys"
+      abort 1
 	fi
-	if [ $? -ne 0 ]; then
-		error "HTTP request failed"
-		abort 1
+	if [[ $? -ne 0 ]]
+    then
+      error "HTTP request failed"
+      abort 1
 	fi
 
-	local success=$(echo "$response" | jq -r ".success")
-	if [ "$success" != true ]; then
-		error "CloudFlare request failed"
-		error "Response: $response"
-		abort 1
+	local success=$( printf "%s" "${response}" | jq -r ".success" )
+	if [[ "${success}" != true ]]
+    then
+      error "CloudFlare request failed"
+      error "Response: ${response}"
+      abort 1
 	fi
 
-	echo "$response"
+	printf "%s" "${response}"
 }
 
-get_domain() {
-	local fqdn="$1"
-
-	awk -v fqdn="$fqdn" '
-		BEGIN {
-			best=""
-		}
-
-		{
-			# Remove comments
-			gsub(/\/\/.*/, "")
-
-			# Remove spaces
-			gsub(/[ \t]/, "")
-
-			# If blank, skip
-			if (length($0) == 0)
-				next
-
-			# Add leading dot
-			tld="." $0
-
-			# Check if this new TLD is longer and matches
-			if (length(tld) > length(best) && substr(fqdn, length(fqdn) - length(tld) + 1) == tld) {
-				best=tld
-			}
-		}
-
-		END {
-			# Remove TLD
-			domain=substr(fqdn, 1, length(fqdn) - length(best))
-
-			# Remove everything before the last dot - all subdomains, that is
-			gsub(/^.*\./, "", domain)
-
-			# Print appending TLD
-			print domain best
-		}
-	' /usr/share/publicsuffix/effective_tld_names.dat
+get_domain () {
+	local fqdn="${1}"
+  if [[ $( printf "%s" "${fqdn}" | awk -F '.' '{ print NF }' ) -gt "2" ]]
+    then
+      printf "%s" "${fqdn}" | awk -F '.' '{ print $(NF-1)"."$NF }'
+    else
+      printf "%s" "${fqdn}"
+  fi
 }
 
-get_zone_id() {
-	local fqdn="$1"
-	local domain=$(get_domain "$fqdn")
+get_zone_id () {
+	local fqdn="${1}"
+	local domain=$( get_domain "$fqdn" )
 
-	log "Requesting zone ID for $fqdn (domain: $domain)"
+	log "Requesting zone ID for ${fqdn} (domain: ${domain})"
 
-	local id=$(cf_req "https://api.cloudflare.com/client/v4/zones?name=${domain}" | jq -r ".result[0].id")
+	local id=$(  cf_req "https://api.cloudflare.com/client/v4/zones?name=${domain}" \
+               | jq -r ".result[0].id"
+            )
 
-	if [ "$id" == null ]; then
-		error "Unable to get zone ID for $fqdn"
-		abort 1
+	if [[ "${id}" == null ]]
+    then
+      error "Unable to get zone ID for ${fqdn}"
+      abort 1
 	fi
 
-	success "Zone ID: $id"
+	success "Zone ID: ${id}"
 
-	echo "$id"
+	printf "%s" "${id}"
 }
 
-wait_for_publication() {
-	local fqdn="$1"
-	local type="$2"
-	local content="$3"
+wait_for_publication () {
+	local fqdn="${1}"
+	local type="${2}"
+	local content="${3}"
 
 	local retries=12
 	local delay=1000
 	local delaySec
 
-	while true; do
-		if dig +noall +answer @ns.cloudflare.com "$fqdn" "$type" | awk '{print $5}' | grep -qF "$content"; then
-			return
-		fi
+	while true
+    do
+      if ( dig +noall +answer @ns.cloudflare.com "${fqdn}" "${type}" \
+          | awk '{ print $5 }' \
+          | grep -qF "${content}"
+        )
+        then
+          return
+      fi
 
-		if [ $retries -eq 0 ]; then
-			error "Record $fqdn did not get published in time"
-			abort 1
-		else
-			delaySec=${delay:0:(-3)}.${delay:(-3)}
-			log "Waiting $delaySec seconds..."
-			sleep $delaySec
+      if [[ ${retries} -eq 0 ]]
+        then
+          error "Record ${fqdn} did not get published in time"
+          abort 1
+        else
+          delaySec=${delay:0:(-3)}.${delay:(-3)}
+          log "Waiting ${delaySec} seconds..."
+          sleep ${delaySec}
 
-			retries=$(($retries - 1))
-			delay=$(($delay * 15 / 10))
-		fi
+          retries=$((retries - 1))
+          delay=$((delay * 15 / 10))
+      fi
 	done
 }
 
-create_record() {
-	local zone="$1"
-	local fqdn="$2"
-	local type="$3"
-	local content="$4"
+create_record () {
+	local zone="${1}"
+	local fqdn="${2}"
+	local type="${3}"
+	local content="${4}"
 	local recordid
 
-	log "Creating record $fqdn $type $content"
+	log "Creating record ${fqdn} ${type} ${content}"
 
-	recordid=$(cf_req -X POST "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records" \
-		--data "{\"type\":\"${type}\",\"name\":\"${fqdn}\",\"content\":\"${content}\"}" |
-		jq -r ".result.id")
+	recordid=$( cf_req -X POST "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records" \
+		          --data "{\"type\":\"${type}\",\"name\":\"${fqdn}\",\"content\":\"${content}\"}" \
+              | jq -r ".result.id"
+            )
 
-	if [ "$recordid" == null ]; then
-		error "Error creating DNS record"
-		abort 1
+	if [[ "${recordid}" == null ]]
+    then
+      error "Error creating DNS record"
+      abort 1
 	fi
 
-	echo "$recordid"
+	printf "%s" "${recordid}"
 }
 
-list_record_id() {
-	local zone="$1"
-	local fqdn="$2"
+list_record_id () {
+	local zone="${1}"
+	local fqdn="${2}"
 
-	cf_req "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records?name=${fqdn}" |
-	jq -r ".result[] | .id"
+	cf_req "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records?name=${fqdn}" \
+  |	jq -r ".result[] | .id"
 }
 
-delete_records() {
-	local zone="$1"
-	local fqdn="$2"
+delete_records () {
+	local zone="${1}"
+	local fqdn="${2}"
 
-	log "Deleting record(s) for $fqdn"
+	log "Deleting record(s) for ${fqdn}"
 
-	list_record_id "$zone" "$fqdn" |
-	while read recordid; do
-		log " - Deleting $recordid"
-		cf_req -X DELETE "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records/${recordid}" >/dev/null
+	list_record_id "${zone}" "${fqdn}" \
+  |	while read recordid
+      do
+        log " - Deleting ${recordid}"
+        cf_req -X DELETE "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records/${recordid}" >/dev/null
 	done
 }
 
-deploy_challenge() {
-	local fqdn="$2"
-	local token="$4"
-	local zoneid=$(get_zone_id "$fqdn")
+deploy_challenge () {
+	local fqdn="${2}"
+	local token="${4}"
+	local zoneid=$(get_zone_id "${fqdn}")
 
-	recordid=$(create_record "$zoneid" "_acme-challenge.$fqdn" TXT "$token")
-	wait_for_publication "_acme-challenge.$fqdn" TXT "\"$token\""
+	recordid=$(create_record "${zoneid}" "_acme-challenge.${fqdn}" TXT "${token}")
+	wait_for_publication "_acme-challenge.${fqdn}" TXT "\"${token}\""
 
-	success "challenge created - CF ID: $recordid"
+	success "challenge created - CF ID: ${recordid}"
 }
 
-clean_challenge() {
-	local fqdn="$2"
-	local zoneid=$(get_zone_id "$fqdn")
+clean_challenge () {
+	local fqdn="${2}"
+	local zoneid=$(get_zone_id "${fqdn}")
 
-	delete_records "$zoneid" "_acme-challenge.$fqdn"
+	delete_records "${zoneid}" "_acme-challenge.${fqdn}"
 }
 
-case $1 in
+case ${1} in
 	deploy_challenge)
-		deploy_challenge $*
-		;;
-
+		deploy_challenge "${@}"
+	;;
 	clean_challenge)
-		clean_challenge $*
-		;;
+		clean_challenge "${@}"
+	;;
 esac

--- a/cftoken
+++ b/cftoken
@@ -1,0 +1,1 @@
+CF_TOKEN=


### PR DESCRIPTION
Hello, i found this script very useful and good written. But it had a few minor things that i didnt like about it. So i changed them.

What was done:

* Removed shellcheck errors (the fixable ones)
* Moved from echo to printf
* Made functions and overall code more easily readable
* Simplified the get_domain function (should work for all domains and removes the need for the publicsuffix package)
* Added a few best practices

The script was tested by me a few times with letsencrypt and zerossl (to be sure) and everything worked fine.
Wildcard domains and subdomains were also tested.

The next step for me is to allow multiple API Tokens for different domains, but that's not needed for me right now, so the priority to get that working is low from my side.

If there are any questions or things that still need to be done, just comment it.
Best regards