### PR TITLE
Update README.md to reflect dig dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Requirements
  * [mawk](http://invisible-island.net/mawk/mawk.html) or [GNU AWK](https://www.gnu.org/software/gawk/)
  * [jq](https://github.com/stedolan/jq)
  * [publicsuffix](https://packages.debian.org/stable/publicsuffix)
+ * [dig](https://packages.debian.org/stable/dnsutils)
 
 All the packages are available on the latest [Debian](https://debian.org) stable (jessie, at the time of writing), and may be installed using:
 ```bash


### PR DESCRIPTION
dig is required by the script, but this dependency is not listed with the others