### PR TITLE
Safeguard against already existing _acme-challenge records

### DIFF
--- a/cf-hook.sh
+++ b/cf-hook.sh
@@ -86,6 +86,14 @@ get_domain() {
 	' /usr/share/publicsuffix/effective_tld_names.dat
 }
 
+list_record_id() {
+	local zone="$1"
+	local fqdn="$2"
+
+	cf_req "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records?name=${fqdn}" |
+	jq -r ".result[] | .id"
+}
+
 get_zone_id() {
 	local fqdn="$1"
 	local domain=$(get_domain "$fqdn")
@@ -139,6 +147,19 @@ create_record() {
 	local content="$4"
 	local recordid
 
+        log "Checking for already existing record $fqdn"
+        if [ ! `list_record_id "$zone" "$fqdn"` == null ]; then 
+                log "Existing record found (from previous failed attempt?) Deleting."
+                list_record_id "$zone" "$fqdn" |
+                while read recordid; do
+                        log " - Deleting $recordid"
+                        cf_req -X DELETE "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records/${recordid}" >/dev/null
+                done
+        else
+                log "No existing record"
+        fi
+
+
 	log "Creating record $fqdn $type $content"
 
 	recordid=$(cf_req -X POST "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records" \
@@ -151,14 +172,6 @@ create_record() {
 	fi
 
 	echo "$recordid"
-}
-
-list_record_id() {
-	local zone="$1"
-	local fqdn="$2"
-
-	cf_req "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records?name=${fqdn}" |
-	jq -r ".result[] | .id"
 }
 
 delete_records() {


### PR DESCRIPTION
I noticed that sometimes my renewal would fail, either because of a timeout or something else. In these cases, the `_acme-challenge` record wouldn't be cleaned up and then any future runs of the renewal would then fail because the record already exists (`ERROR: Response: {"result":null,"success":false,"errors":[{"code":81057,"message":"Record already exists."}],"messages":[]}`)

This adds a simple check to see if the record already exists, and deletes it if it does. I considered trying to clean up after failure instead, but this actually catches other potential sources of `_acme-challenge`, such as if multiple tools are used.